### PR TITLE
add rev6-7 support

### DIFF
--- a/devices/r4igold3ds.cpp
+++ b/devices/r4igold3ds.cpp
@@ -1,4 +1,4 @@
-#include "device.h"
+#include "../device.h"
 
 #include <cstring>
 #include <algorithm>


### PR DESCRIPTION
And maybe rev8 but I haven't seen anybody with this card yet.

We still need more command C7 samples from users to safely determine r4ids.cn revisions.
@d3m3vilurr knows what I mean by this. Might need to open some rev4-5 issues and ask users as I did here: https://github.com/ntrteam/flashcart_core/issues/9#issuecomment-344408217

But this did work for me on my 3 r4igolds and at least two other users on rev6 and 7. This should complete full support for the r4ids.cn : )