### PR TITLE
Update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,32 @@ __A *hopefully* reusable component for dealing with flashcart specific behavior.
 
 ## Usage
 End users cannot use this directly, and should use one of the following applications:
- - [ntrboot_flasher](https://github.com/kitling/ntrboot_flasher) for the 3ds
- - [ak2i_ntrcardhax_flasher](https://github.com/d3m3vilurr/ak2i_ntrcardhax_flasher) for use through DS flashcarts.
+ - [ntrboot_flasher](https://github.com/kitling/ntrboot_flasher) for the 3DS
+ - [ntrboot_flasher_nds](https://github.com/jason0597/ntrboot_flasher_nds) for use through DS flashcarts.
 
 ## Supported Carts
-![From Left to Right: Acekard 2i HW81, Acekard 2i HW44, R4i Gold 3DS RTS, R4i Gold 3DS, R4i Ultra, R4 3D Revolution, DSTT, R4i-SDHC RTS Lite, R4i-SDHC Dual-Core, R4-SDHC Gold Pro, R4i 3DS RTS, Infinity 3 R4i, R4i Gold 3DS Deluxe Edition, R4i-B9S](https://i.lolis.stream/uploads/big/6c535398c6a74d580ffc9092c32d7687.png)
-- Acekard 2i HW-44
+![From Left to Right: Acekard 2i HW81, Acekard 2i HW44, R4i Gold 3DS RTS, R4i Gold 3DS, R4i Ultra, R4 3D Revolution, DSTT, R4i-SDHC RTS Lite, R4i-SDHC Dual-Core, R4-SDHC Gold Pro, R4i 3DS RTS, Infinity 3 R4i, R4i Gold 3DS Deluxe Edition, R4i-B9S](https://www.dropbox.com/s/1quom0d490wnpfd/flashcart_core_compatible_flashcarts.png?raw=1)
+
 - Acekard 2i HW-81
-- DSTT (**some flash chips only!**)
-- Infinity 3 R4i (r4infinity.com)
-- R4 3D Revolution (r4idsn.com)
-- R4i 3DS RTS (r4i-sdhc.com)
+- Acekard 2i HW-44
+- R4i Ultra (r4ultra.com)
 - R4i Gold 3DS (RTS, revisions A5/A6/A7) (r4ids.cn)
 - R4i Gold 3DS Deluxe Edition (r4ids.cn) (**variants of this such as 3dslink, Orange 3DS, etc. may work as well, but have not been tested!**)
-- R4i Ultra (r4ultra.com)
+- Infinity 3 R4i (r4infinity.com)
+- R4 3D Revolution (r4idsn.com)
+- DSTT (**some flash chips only!**)
+
+**Note:** Flashcarts from r4isdhc.com tend to have yearly re-releases; all versions of these carts (2014-2018) should work but not all have been tested. 2013 and older models are not currently supported.
+
+- R4i 3DS RTS (r4i-sdhc.com)
 - R4i-B9S (r4i-sdhc.com)
-- R4i-SDHC Dual-Core (r4isdhc.com)
 - R4i-SDHC Gold Pro (r4isdhc.com)
+- R4i-SDHC Dual-Core (r4isdhc.com)
 - R4i-SDHC RTS Lite (r4isdhc.com)
-
-**Note:** Flashcarts from r4isdhc.com tend to have yearly re-releases; all versions of these carts (2014-2017) should work but not all have been tested. 
-
-### Planned Carts
- - Supercard DSTWO
+- Ace3DS
+- Ace3DS Plus
+- Gateway Blue card (**not all work!**)
+- R4iSDHC dual-core (r4isdhc.com.cn); not to be confused with the dual-core from r4isdhc.**com** or r4isdhc.**hk**
 
 ## Requesting support for a new cart
 We get a lot of requests for new carts to be supported. Before requesting support, please read other issues, both open and closed, to see if your cart has been considered or not. If you'd like your cart to be supported please provide, at the very least, the following information:
@@ -36,7 +39,23 @@ We get a lot of requests for new carts to be supported. Before requesting suppor
  - Any other pertinent information, like any known commands for interacting with the cart.
 
 ## Developer Usage
-Define `Flashcart::platformInit`, `Flashcart::sendCommand`, and `Flashcart::showProgress`, and use `Flashcart::detectCart` to detect whatever you have. Then you can use the methods on the returned device to preform stuff in a (mostly) device-independent manner.
+If you want to use flashcart_core in your project, you will need [libncgc](https://github.com/angelsl/libncgc/) as well.
+
+You will need to reopen the flashcart_core::platform namespace, and inside it define:
+1. `showProgress()`, used to show current percentage of a given operation (e.g. drawing a green rectangle to represent percentage)
+2. `logMessage()`, used to log things from the various flashcart classes to something that the user can read, e.g. a text file or printouts to the screen; **note:** you will need `va_list` for this
+4. `getBlowfisKey()`, used by the various flashcart classes to retrieve blowfish keys. You have to provide these blowfish keys yourself through e.g. a u8 array or using a .bin linker
+
+Then you can make an object from [one of the flashcart_core classes](https://github.com/ntrteam/flashcart_core/tree/master/devices), and then use the public functions inside that class.
+For example:
+
+```cpp
+R4i_Gold_3DS R4iGold;
+R4iGold.initialize();
+R4iGold.injectNtrBoot(blowfish_key, firm, firm_size);
+```
+
+Write your makefile so that it makes libncgc.a first, then compiles your project normally using flashcart_core.
 
 ## Porting flashcart_core to a new flashcart
 ### Information needed for a new cart.
@@ -48,10 +67,12 @@ Define `Flashcart::platformInit`, `Flashcart::sendCommand`, and `Flashcart::show
 This software is licensed under the terms of the GPLv3.
 You can find a copy of the license in the LICENSE file.
 
-## Credits
-[@Normmatt](https://github.com/Normmatt) for bug squashing, expertiese... etc.  
-[@SciresM](https://twitter.com/SciresM) for sighax/boot9strap  
-[@hedgeberg](https://twitter.com/hedgeberg) for testing and inspiration.  
-[@stuckpixel](https://twitter.com/pixel_stuck) for testing.  
-[@Myria](https://twitter.com/Myriachan) for testing.  
-[@Hikari](https://twitter.com/yuukishiroko) for testing.
+## Credits (in no particular order)
+- [@Normmatt](https://github.com/Normmatt) for bug squashing, expertiese... etc.  
+- [@SciresM](https://twitter.com/SciresM) for sighax/boot9strap  
+- [@hedgeberg](https://twitter.com/hedgeberg) for testing and inspiration.  
+- [@angelsl](https://github.com/angelsl) for libncgc and other things
+- [@zoogie](https://github.com/zoogie) for r4igold support
+- [@stuckpixel](https://twitter.com/pixel_stuck) for testing.  
+- [@Myria](https://twitter.com/Myriachan) for testing.  
+- [@Hikari](https://twitter.com/yuukishiroko) for testing.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ End users cannot use this directly, and should use one of the following applicat
  - [ntrboot_flasher_nds](https://github.com/jason0597/ntrboot_flasher_nds) for use through DS flashcarts.
 
 ## Supported Carts
-![From Left to Right: Acekard 2i HW81, Acekard 2i HW44, R4i Gold 3DS RTS, R4i Gold 3DS, R4i Ultra, R4 3D Revolution, DSTT, R4i-SDHC RTS Lite, R4i-SDHC Dual-Core, R4-SDHC Gold Pro, R4i 3DS RTS, Infinity 3 R4i, R4i Gold 3DS Deluxe Edition, R4i-B9S](https://www.dropbox.com/s/1quom0d490wnpfd/flashcart_core_compatible_flashcarts.png?raw=1)
+![From Left to Right: Acekard 2i HW81, Acekard 2i HW44, R4i Gold 3DS RTS, R4i Gold 3DS, R4i Ultra, R4 3D Revolution, DSTT, R4i-SDHC RTS Lite, R4i-SDHC Dual-Core, R4-SDHC Gold Pro, R4i 3DS RTS, Infinity 3 R4i, R4i Gold 3DS Deluxe Edition, R4i-B9S, Ace3DS Plus, Gateway Blue, R4iSDHC Dual-Core (r4isdhc.com.cn)](https://www.dropbox.com/s/ntn9kcjdukmhoz0/flashcart_core_compatible_flashcarts.png?raw=1)
 
 - Acekard 2i HW-81
 - Acekard 2i HW-44
@@ -25,7 +25,6 @@ End users cannot use this directly, and should use one of the following applicat
 - R4i-SDHC Gold Pro (r4isdhc.com)
 - R4i-SDHC Dual-Core (r4isdhc.com)
 - R4i-SDHC RTS Lite (r4isdhc.com)
-- Ace3DS
 - Ace3DS Plus
 - Gateway Blue card (**not all work!**)
 - R4iSDHC dual-core (r4isdhc.com.cn); not to be confused with the dual-core from r4isdhc.**com** or r4isdhc.**hk**


### PR DESCRIPTION
Seeing as it hasn't been updated in a while, it was time to update this to reflect the changes that have occured over the past few months.

Changes include:

- Update the image and the list to show Ace3DS/GW blue/r4isdhc.com.cn
Note that I have not included the older R4iGold revisions in the image. Possibly missing a few other carts as well.
- Move from ds_ntrboot_flasher/ak2i_ntrcardhax_flasher to ntrboot_flasher_nds
- Update the developer information to mention how flashcart_core is used now, and how you need ncgc for it now
- Mention some extra people in the credits

Also, if you don't like the fact that I am hosting the image on dropbox, let me know
